### PR TITLE
WIP: Flags and replacing variants

### DIFF
--- a/src/Banner.tsx
+++ b/src/Banner.tsx
@@ -1,10 +1,105 @@
-import { variant } from 'styled-system'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { Box } from './Box'
+import { useFlags } from './useFlags'
 
-let bannerVariant = variant({
-  scale: 'banners',
-  prop: 'variant',
+export let Banner = styled(Box)(({ theme, variant }) => {
+  let flags = useFlags()
+
+  if (flags.useCSSVars) {
+    switch (variant) {
+      case 'success': {
+        return css`
+          color: var(--colors-black, ${theme.colors.black});
+          background-color: var(--colors-teal-2, ${theme.colors.teal[2]});
+          border: solid 2px var(--colors-teal-6, ${theme.colors.teal[6]});
+          border-radius: var(--radii-0, ${theme.radii[0]});
+          padding: var(--space-3, ${theme.space[3]});
+          display: flex;
+          align-items: center;
+        `
+      }
+      case 'error': {
+        return css`
+          color: var(--colors-black, ${theme.colors.black});
+          background-color: var(--colors-red-2, ${theme.colors.red[2]});
+          border: solid 2px var(--colors-red-6, ${theme.colors.red[6]});
+          border-radius: var(--radii-0, ${theme.radii[0]});
+          padding: var(--space-3, ${theme.space[3]});
+          display: flex;
+          align-items: center;
+        `
+      }
+      case 'warning': {
+        return css`
+          color: var(--colors-black, ${theme.colors.black});
+          background-color: var(--colors-yellow-2, ${theme.colors.yellow[2]});
+          border: solid 2px var(--colors-yellow-6, ${theme.colors.yellow[6]});
+          border-radius: var(--radii-0, ${theme.radii[0]});
+          padding: var(--space-3, ${theme.space[3]});
+          display: flex;
+          align-items: center;
+        `
+      }
+      default:
+      case 'info': {
+        return css`
+          color: var(--colors-black, ${theme.colors.black});
+          background-color: var(--colors-blue-2, ${theme.colors.blue[2]});
+          border: solid 2px var(--colors-blue-6, ${theme.colors.blue[6]});
+          border-radius: var(--radii-0, ${theme.radii[0]});
+          padding: var(--space-3, ${theme.space[3]});
+          display: flex;
+          align-items: center;
+        `
+      }
+    }
+  }
+
+  switch (variant) {
+    case 'success': {
+      return css`
+        color: ${theme.colors.black};
+        background-color: ${theme.colors.teal[2]};
+        border: solid 2px ${theme.colors.teal[6]};
+        border-radius: ${theme.radii[0]};
+        padding: ${theme.space[3]};
+        display: flex;
+        align-items: center;
+      `
+    }
+    case 'error': {
+      return css`
+        color: ${theme.colors.black};
+        background-color: ${theme.colors.red[2]};
+        border: solid 2px ${theme.colors.red[6]};
+        border-radius: ${theme.radii[0]};
+        padding: ${theme.space[3]};
+        display: flex;
+        align-items: center;
+      `
+    }
+    case 'warning': {
+      return css`
+        color: ${theme.colors.black};
+        background-color: ${theme.colors.yellow[2]};
+        border: solid 2px ${theme.colors.yellow[6]};
+        border-radius: ${theme.radii[0]};
+        padding: ${theme.space[3]};
+        display: flex;
+        align-items: center;
+      `
+    }
+    default:
+    case 'info': {
+      return css`
+        color: ${theme.colors.black};
+        background-color: ${theme.colors.blue[2]};
+        border: solid 2px ${theme.colors.blue[6]};
+        border-radius: ${theme.radii[0]};
+        padding: ${theme.space[3]};
+        display: flex;
+        align-items: center;
+      `
+    }
+  }
 })
-
-export let Banner = styled(Box)(bannerVariant)

--- a/src/ThemeProvider.tsx
+++ b/src/ThemeProvider.tsx
@@ -4,7 +4,7 @@ import {
   ThemeProvider as StyledProvider,
   DefaultTheme,
 } from 'styled-components'
-import { flagContext, Flags } from './flagContext'
+import { flagContext, Flags, defaultFlags } from './flagContext'
 
 export let themeContext = React.createContext<DefaultTheme>(defaultTheme)
 
@@ -16,7 +16,7 @@ interface Props {
 
 export function ThemeProvider({
   theme = defaultTheme,
-  flags,
+  flags = defaultFlags,
   children,
 }: Props) {
   return (

--- a/src/ThemeProvider.tsx
+++ b/src/ThemeProvider.tsx
@@ -4,21 +4,26 @@ import {
   ThemeProvider as StyledProvider,
   DefaultTheme,
 } from 'styled-components'
+import { flagContext, Flags } from './flagContext'
 
-export let themeContext = React.createContext(defaultTheme)
+export let themeContext = React.createContext<DefaultTheme>(defaultTheme)
 
 interface Props {
   theme?: DefaultTheme
+  flags?: Flags
   children: any
 }
 
-export function ThemeProvider({ theme = defaultTheme, children }: Props) {
+export function ThemeProvider({
+  theme = defaultTheme,
+  flags,
+  children,
+}: Props) {
   return (
-    <themeContext.Provider
-      // @ts-ignore
-      value={theme}
-    >
-      <StyledProvider theme={theme}>{children}</StyledProvider>
+    <themeContext.Provider value={theme}>
+      <flagContext.Provider value={flags}>
+        <StyledProvider theme={theme}>{children}</StyledProvider>
+      </flagContext.Provider>
     </themeContext.Provider>
   )
 }

--- a/src/flagContext.tsx
+++ b/src/flagContext.tsx
@@ -1,6 +1,6 @@
 import { createContext } from 'react'
 
-let defaultFlags = {
+export let defaultFlags = {
   useCSSVars: false,
 }
 

--- a/src/flagContext.tsx
+++ b/src/flagContext.tsx
@@ -1,0 +1,10 @@
+import { createContext } from 'react'
+
+let defaultFlags = {
+  useCSSVars: false,
+}
+
+export interface Flags {
+  useCSSVars?: boolean
+}
+export let flagContext = createContext<Flags>(defaultFlags)

--- a/src/useFlags.tsx
+++ b/src/useFlags.tsx
@@ -1,0 +1,6 @@
+import { flagContext } from './flagContext'
+import { useContext } from 'react'
+
+export function useFlags() {
+  return useContext(flagContext)
+}

--- a/types/styled.d.ts
+++ b/types/styled.d.ts
@@ -30,7 +30,6 @@ declare module 'styled-components' {
     space: Array<number>
     fontSizes: any
     colors: {
-      base: string
       black: string
       white: string
       primary: string


### PR DESCRIPTION
Changes:

* New `flags` prop on `ThemeProvider`
  * Initial supported value: `{ useCSSVars: boolean }`
* Replacing `variant` in `Banner`s with switch inline + implementation of CSS Vars support


### TODO:

* [ ] Switch variants in other components
* [ ] Implement CSS Vars in the Reset component
* [ ] Secret project 1